### PR TITLE
Resolve Vue race conditions when adding matrix blocks with an address field in Craft 5

### DIFF
--- a/src/web/assets/src/vue/address/address-map.vue
+++ b/src/web/assets/src/vue/address/address-map.vue
@@ -300,6 +300,9 @@ export default {
          */
         _updateMarkerPosition()
         {
+            // Prevent crashes if coordinates change but the map marker hasn't been initialized yet
+            if (!this.marker) return;
+            
             // Get the Pinia store
             const addressStore = useAddressStore()
 
@@ -329,6 +332,9 @@ export default {
          */
         _updateZoomLevel()
         {
+            // Prevent crashes if zoom level changes but the map instance hasn't been initialized yet
+            if (!this.map) return;
+            
             // Get the Pinia store
             const addressStore = useAddressStore();
 

--- a/src/web/assets/src/vue/address/address-subfields.vue
+++ b/src/web/assets/src/vue/address/address-subfields.vue
@@ -65,28 +65,10 @@ import { toRaw } from 'vue';
 
 export default {
     data() {
-        // If libraries have not yet been defined
-        if (!window.mapboxsearchcore) {
-            // Log error and bail
-            console.warn('[MB] Unable to load the Mapbox search libraries.');
-        }
-
-        // Extract search libraries
-        const {
-            SearchBoxCore,
-            SearchSession
-        } = window.mapboxsearchcore;
-
-        // Configure the search options
-        const options = this.configureOptions();
-
-        // Configure search session
-        const search = new SearchBoxCore(options);
-        const session = new SearchSession(search, 200); // Debounce 2 of 2
-
-        // Return data
+        // Return data with a null session initially.
+        // We will initialize the session in mounted() once the external Mapbox libraries are fully loaded.
         return {
-            'session': session,
+            'session': null,
             'resultsLeft': '0',
             'resultsWidth': '400px',
         }
@@ -102,7 +84,29 @@ export default {
         }
     },
     mounted() {
-        this.listeners();
+        // Asynchronously wait for the external Mapbox search libraries to be available
+        // This prevents race conditions when Matrix blocks are dynamically added in Craft 5
+        const initMapbox = () => {
+            if (!window.mapboxsearchcore || typeof window.mapboxsearchcore.SearchBoxCore === 'undefined') {
+                setTimeout(initMapbox, 100);
+                return;
+            }
+
+            // Extract search libraries
+            const { SearchBoxCore, SearchSession } = window.mapboxsearchcore;
+
+            // Configure the search options
+            const options = this.configureOptions();
+
+            // Configure search session and assign it to our component data
+            const search = new SearchBoxCore(options);
+            this.session = new SearchSession(search, 200); // Debounce 2 of 2
+
+            // Start the listeners only after the session has been successfully created
+            this.listeners();
+        };
+
+        initMapbox();
     },
     methods: {
 
@@ -282,6 +286,9 @@ export default {
          */
         search(searchValue)
         {
+            // Prevent errors if the user types before the Mapbox session is fully initialized
+            if (!this.session) return;
+            
             // Perform search
             toRaw(this.session).suggest(searchValue);
 
@@ -294,6 +301,9 @@ export default {
          */
         retrieve(suggestion)
         {
+            // Prevent errors if retrieval is triggered before the Mapbox session is fully initialized
+            if (!this.session) return;
+            
             // Retrieve suggestion info
             toRaw(this.session).retrieve(suggestion);
 


### PR DESCRIPTION
## Description
This PR resolves a critical Vue.js race condition that occurs in Craft 5 when adding a matrix block with an address field in Craft 5.

Currently, when a user clicks "New block", the field fails to render and the browser console throws a `Cannot read properties of undefined (reading 'SearchBoxCore')` error. Additionally, if an address is selected too quickly via autofill before the map is fully rendered, it throws a `Cannot read properties of null (reading 'setLngLat')` error.

## The Fix
* **`address-subfields.vue`**: Moved the Mapbox initialization out of the `data()` hook and into the `mounted()` hook, wrapped in a short polling loop (`setTimeout`) to patiently wait for `window.mapboxsearchcore` to become available. Added safety checks to `search()` and `retrieve()` to prevent errors if a user types before the session is ready.
* **`address-map.vue`**: Added simple `if (!this.marker) return;` and `if (!this.map) return;` safety checks to prevent crashes during rapid state changes.

## Steps to Reproduce (Craft 5)
1. Create a Matrix field in Craft 5.
2. Add a block type containing the Mapbox 'Address' field.
3. Go to an entry and click "New block" to add the block containing the address field.
4. Observe the console error and the blank field.

## Testing Done
I have manually tested these changes locally in a Craft 5 environment. 
- [x] Dynamically adding a new Matrix block now immediately renders the Mapbox field without console errors.
- [x] Fast autofill selections update the data correctly without crashing the map component.